### PR TITLE
Fix for vertexai/git-big#9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -f requirements*.txt
 	rm -rf build
 	rm -rf dist
-	find -name *.pyc -delete
+	find . -name *.pyc -delete
 
 %.txt: %.in
 	pip-compile $<
@@ -38,5 +38,8 @@ publish: ${WHEEL}
 	git push --tag
 	twine upload ${WHEEL}
 
-test:
+install:
+	pip install -e .
+
+test: install
 	pytest

--- a/git_big/storage.py
+++ b/git_big/storage.py
@@ -96,10 +96,10 @@ class LibcloudStorage(Storage):
 
     def has_object(self, obj_path):
         try:
-            self.bucket.get_object(obj_path)
-            return True
+            obj = self.bucket.get_object(obj_path)
+            return obj.size
         except ObjectDoesNotExistError:
-            return False
+            return None
 
     def delete_object(self, obj_path):
         try:
@@ -165,7 +165,9 @@ class BotoStorage(Storage):
 
     def has_object(self, obj_path):
         key = self.bucket.get_key(obj_path)
-        return key is not None
+        if key:
+            return key.size
+        return None
 
     def delete_object(self, obj_path):
         self.bucket.delete_key(obj_path)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,12 +4,11 @@
 #
 #    pip-compile --output-file requirements-dev.txt requirements-dev.in
 #
-argparse==1.4.0           # via pip-review
 astroid==1.5.3            # via pylint
 backports.functools-lru-cache==1.4  # via astroid, pylint
 blessings==1.6            # via curtsies
 bpython==0.16
-certifi==2017.4.17        # via requests
+certifi==2017.11.5        # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
 configparser==3.5.0       # via pylint
@@ -17,26 +16,27 @@ curtsies==0.2.11          # via bpython
 enum34==1.1.6             # via astroid
 first==2.0.1              # via pip-tools
 greenlet==0.4.12          # via bpython
-idna==2.5                 # via requests
+idna==2.6                 # via requests
 isort==4.2.15             # via pylint
 lazy-object-proxy==1.3.1  # via astroid
 lockfile==0.12.2
 mccabe==0.6.1             # via pylint
 packaging==16.8           # via pip-review
-pip-review==0.5.3
-pip-tools==1.9.0
+pip-review==1.0
+pip-tools==1.10.1
 pkginfo==1.4.1            # via twine
-py==1.4.34                # via pytest
+py==1.5.2                 # via pytest
 pygments==2.2.0           # via bpython
-pylint==1.7.1
-pytest==3.1.2
+pylint==1.7.4
+pyparsing==2.2.0          # via packaging
+pytest==3.2.5
 requests-toolbelt==0.8.0  # via twine
-requests==2.17.3          # via bpython, requests-toolbelt, twine
+requests==2.18.4          # via bpython, requests-toolbelt, twine
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.10.0               # via astroid, bpython, pip-tools, pylint, singledispatch
-tqdm==4.14.0              # via twine
+six==1.11.0               # via astroid, bpython, packaging, pip-tools, pylint, singledispatch
+tqdm==4.19.4              # via twine
 twine==1.9.1
-urllib3==1.21.1           # via requests
+urllib3==1.22             # via requests
 wcwidth==0.1.7            # via curtsies
-wrapt==1.10.10            # via astroid
-yapf==0.16.2
+wrapt==1.10.11            # via astroid
+yapf==0.20.0


### PR DESCRIPTION
This introduces two modes for the `pull` command:

- *soft*: Link up files that exist in the local cache, otherwise print a missing object warning.
- *hard*: Link up all files by pulling missing files from the configured depot.

By default, all commands that involve the pull operation now run in *soft* mode. To override this behavior, users may use `--hard` option with the `pull` and `clone` commands.

In addition, the `pull` command now takes positional `path` arguments, to be used for manually fetching files from a depot if they don't exist locally; this implies *hard* mode.

This PR also adds a file size column to the `status` command.