### PR TITLE
Ensure recent version of setuptools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 /.tox
 /Pipfile.lock
 /.eggs
+/.env

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ install:
 	pip install -e .
 
 dev:
+	./configure
 	@echo 'You need to install minio to run tests'
 	@echo 'See: https://docs.minio.io/docs/minio-quickstart-guide'
 	pipenv install --dev

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	git clean -fxd
 
 ${WHEEL}: setup.py git_big/*.py
-	python $< bdist_wheel
+	pipenv run python $< bdist_wheel
 
 publish: ${WHEEL}
 	git tag ${VERSION}

--- a/configure
+++ b/configure
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat << EOF > .env
+PYTHON=$(pipenv --py)
+EOF

--- a/git_big/__init__.py
+++ b/git_big/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.6.4'
+__version__ = '0.6.3'

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,4 @@
 from setuptools import setup
 
 if __name__ == '__main__':
-    setup()
+    setup(setup_requires=['setuptools>=36.2.7'])


### PR DESCRIPTION
A recent version of setuptools is required to ensure that environment markers are parsed properly from `setup.cfg`
