### PR TITLE
Fix for "Invalid cross-device link" on Linux

### DIFF
--- a/.exclude
+++ b/.exclude
@@ -1,5 +1,6 @@
 *.pyc
 /.env
 /.pytest_cache
+/.tox
 /*.egg-info
 /Pipfile.lock

--- a/.exclude
+++ b/.exclude
@@ -1,0 +1,5 @@
+*.pyc
+/.env
+/.pytest_cache
+/*.egg-info
+/Pipfile.lock

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ dev:
 	./configure
 	@echo 'You need to install minio to run tests'
 	@echo 'See: https://docs.minio.io/docs/minio-quickstart-guide'
-	pipenv install --dev
+	pipenv install --dev -e .
 
 test: dev
 	minio version

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ ${WHEEL}: setup.py git_big/*.py
 	pipenv run python $< bdist_wheel
 
 publish: ${WHEEL}
-	git tag ${VERSION}
+	git tag "v${VERSION}"
 	git push upstream --tag
 	pipenv run twine upload ${WHEEL}
 

--- a/git_big/__init__.py
+++ b/git_big/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/git_big/main.py
+++ b/git_big/main.py
@@ -104,7 +104,10 @@ def atomic_open(dst_path, *args, **kwargs):
             yield file_
         if IS_WIN and os.path.exists(dst_path):
             os.unlink(dst_path)
-        os.rename(tmp_path, dst_path)
+        try:
+            os.rename(tmp_path, dst_path)
+        except:
+            shutil.copy2(tmp_path, dst_path)
     finally:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,8 @@ class Context(object):
             os.makedirs(self.bucket_dir)
 
     def git_big_init(self, depot_config):
+        check_output(['git', 'config', 'user.email', 'you@example.com'])
+        check_output(['git', 'config', 'user.name', 'Your Name'])
         check_output(['git', 'config', 'git-big.cache-dir', self.cache_dir])
         check_output([
             'git',


### PR DESCRIPTION
`os.rename()` can fail if the src and dst paths are on different filesystems (or devices).
Under linux, it's possible the `/tmp` resides on a different device.
This is a workaround for that situation.